### PR TITLE
Update the website description of what wgpu is

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>wgpu-rs | Rust bindings to wgpu native library</title>
+    <title>wgpu: portable graphics library for Rust</title>
 
     <!-- BULMA CSS Framework -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.0/css/bulma.min.css"
@@ -159,16 +159,15 @@
                     </div>
                     <div class="column px-6">
                         <h1 class="title is-1 pb-6">
-                            wgpu-rs
+                            wgpu
                         </h1>
                         <p class="subtitle is-3">
-                            <b>wgpu-rs</b> is an idiomatic <a href="https://www.rust-lang.org/">Rust</a> wrapper
-                            over <a href="https://github.com/gfx-rs/wgpu">wgpu-core</a>. It's designed to be
-                            suitable for general purpose graphics and computation needs of Rust community.
+                            <b>wgpu</b> is a safe and portable graphics API for Rust based on the WebGPU API.
+                            It is suitable for general purpose graphics and computation needs of Rust community.
                         </p>
                         <p class="subtitle is-3">
-                            <b>wgpu-rs</b> can target both the natively supported backends and <a
-                                href="https://webassembly.org/">WebAssembly</a> directly.
+                            Applications using <b>wgpu</b> run natively on Vulkan, Metal, DirectX 11/12, and OpenGL ES;
+                            and browsers via WebAssembly on WebGPU and WebGL2.
                         </p>
                     </div>
                 </div>
@@ -181,7 +180,7 @@
         <div class="container">
             <h1 class="title is-1"><a name="showcase">#</a> Showcase</h1>
             <br>
-            <p class="subtitle is-4">Made something cool with <b>wgpu-rs</b>? Make a PR to <a href="https://github.com/gfx-rs/wgpu-rs.github.io">wgpu-rs.github.io</a>, and reach out to us on <a href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
+            <p class="subtitle is-4">Made something cool with <b>wgpu</b>? <a href="https://github.com/gfx-rs/wgpu-rs.github.io"></a>Make a PR</a>, and reach out to us on <a href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
             <br>
 
             <div id="showcase_container"></div>
@@ -339,31 +338,31 @@
                 "thumbnail": "screenshots/ensnano.png"
             },
             {
-                "name": "wgpu-rs",
+                "name": "wgpu",
                 "description": "Water example",
                 "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/water",
                 "thumbnail": "screenshots/example-water.gif"
             },
             {
-                "name": "wgpu-rs",
+                "name": "wgpu",
                 "description": "Shadow example",
                 "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/shadow",
                 "thumbnail": "screenshots/example-shadow.png"
             },
             {
-                "name": "wgpu-rs",
+                "name": "wgpu",
                 "description": "Cube example",
                 "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/cube",
                 "thumbnail": "screenshots/example-cube.png"
             },
             {
-                "name": "wgpu-rs",
+                "name": "wgpu",
                 "description": "Mipmap example",
                 "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/mipmap",
                 "thumbnail": "screenshots/example-mipmap.png"
             },
             {
-                "name": "wgpu-rs",
+                "name": "wgpu",
                 "description": "Skybox example",
                 "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/skybox",
                 "thumbnail": "screenshots/example-skybox.gif"

--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
                             wgpu
                         </h1>
                         <p class="subtitle is-3">
-                            <b>wgpu</b> is a safe and portable graphics API for Rust based on the WebGPU API.
-                            It is suitable for general purpose graphics and computation needs of Rust community.
+                            <b>wgpu</b> is a safe and portable graphics library for Rust based on the WebGPU API.
+                            It is suitable for general purpose graphics and compute on the GPU.
                         </p>
                         <p class="subtitle is-3">
                             Applications using <b>wgpu</b> run natively on Vulkan, Metal, DirectX 11/12, and OpenGL ES;


### PR DESCRIPTION
This PR updates the info on the website to more clearly represent what wgpu does. It also changes the old name of `wgpu-rs` to just `wgpu` now that the `-rs` suffix was dropped for the name of the user-facing Rust bindings in the architecture. I suggest also updating this repo's description from "Hosting for wgpu-rs website" to "Hosting for wgpu.rs website" (change the dash to a dot).