### PR TITLE
add hello in worker example

### DIFF
--- a/examples-gpu/hello-worker.js
+++ b/examples-gpu/hello-worker.js
@@ -1,0 +1,1 @@
+import("./wasm/hello.js").then(module => module.default());

--- a/examples-gpu/index.html
+++ b/examples-gpu/index.html
@@ -67,6 +67,7 @@
         "skybox",
         // "texture-arrays",
         // "water",
+        "hello-worker",
       ];
       const list = document.createElement("ul");
       for (let exampleName of exampleNames) {
@@ -82,7 +83,10 @@
       const currentExample = new URLSearchParams(window.location.search).get(
         "example"
       );
-      if (currentExample) {
+      if (currentExample === "hello-worker") {
+        console.info("Note: loading modules in web workers is currently not supported on Firefox");
+        const worker = new Worker("hello-worker.js", { type: "module" });
+      } else if (currentExample) {
         import(`./wasm/${currentExample}.js`).then((module) => module.default());
       } else {
         window.location.assign(


### PR DESCRIPTION
This adds a new example `hello-worker` that runs the example `hello` in a web worker.
It depends on [this PR in wgpu](https://github.com/gfx-rs/wgpu/pull/2858) that fixes instance creation in a worker context.
Unfortunately, Firefox doesn't allow loading modules in web workers so it won't work there but it works on Chromium.
I tested this on Linux.