### PR TITLE
Fix the broken links to WGPU examples in main respository

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,31 +366,31 @@
             {
                 "name": "wgpu",
                 "description": "Water example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/water",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/water",
                 "thumbnail": "screenshots/example-water.gif"
             },
             {
                 "name": "wgpu",
                 "description": "Shadow example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/shadow",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/shadow",
                 "thumbnail": "screenshots/example-shadow.png"
             },
             {
                 "name": "wgpu",
                 "description": "Cube example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/cube",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/cube",
                 "thumbnail": "screenshots/example-cube.png"
             },
             {
                 "name": "wgpu",
                 "description": "Mipmap example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/mipmap",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/mipmap",
                 "thumbnail": "screenshots/example-mipmap.png"
             },
             {
                 "name": "wgpu",
                 "description": "Skybox example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples/skybox",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/skybox",
                 "thumbnail": "screenshots/example-skybox.gif"
             }
         ];


### PR DESCRIPTION
Previously, the bottom 5 links to WGPU examples on the website were broken, and linked to incorrect parts of the repository that no longer had the examples. I fixed this by editing them all to be the correct links