### PR TITLE
Remove dx11 from list of backends on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                             It is suitable for general purpose graphics and compute on the GPU.
                         </p>
                         <p class="subtitle is-3">
-                            Applications using <b>wgpu</b> run natively on Vulkan, Metal, DirectX 11/12, and OpenGL ES;
+                            Applications using <b>wgpu</b> run natively on Vulkan, Metal, DirectX 12, and OpenGL ES;
                             and browsers via WebAssembly on WebGPU and WebGL2.
                         </p>
                     </div>


### PR DESCRIPTION
It's been awhile since there's been a working dx11 backend, so imo we shouldn't claim wgpu apps run natively on dx11.