### PR TITLE
Fixed dead example links in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,31 +366,31 @@
             {
                 "name": "wgpu",
                 "description": "Water example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/water",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/src/water",
                 "thumbnail": "screenshots/example-water.gif"
             },
             {
                 "name": "wgpu",
                 "description": "Shadow example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/shadow",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/src/shadow",
                 "thumbnail": "screenshots/example-shadow.png"
             },
             {
                 "name": "wgpu",
                 "description": "Cube example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/cube",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/src/cube",
                 "thumbnail": "screenshots/example-cube.png"
             },
             {
                 "name": "wgpu",
                 "description": "Mipmap example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/mipmap",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/src/mipmap",
                 "thumbnail": "screenshots/example-mipmap.png"
             },
             {
                 "name": "wgpu",
                 "description": "Skybox example",
-                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/skybox",
+                "website": "https://github.com/gfx-rs/wgpu/tree/trunk/examples/src/skybox",
                 "thumbnail": "screenshots/example-skybox.gif"
             }
         ];


### PR DESCRIPTION
I noticed that the official site has a few examples (specifically ones in the official repo's example folder) are not leading to the correct source. This is a very minor pull request, but it is my first public one I have ever done on Github. Hope I didn't break anything 😅