### PR TITLE
Add bindings section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/index.html
+++ b/index.html
@@ -161,17 +161,6 @@
     <!-- Showcase Projects -->
     <section class="section is-medium">
         <div class="container">
-            <h1 class="title is-1"><a name="showcase">#</a> Showcase</h1>
-            <br>
-            <p class="subtitle is-4">Made something cool with <b>wgpu</b>? <a
-                    href="https://github.com/gfx-rs/wgpu-rs.github.io">Make a PR</a>, and reach out to us on <a
-                    href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
-            <br>
-
-            <div id="showcase_container"></div>
-        </div>
-
-        <div class="container">
             <h1 class="title is-1"><a name="bindings">#</a> Bindings</h1>
             <br>
             <p class="subtitle is-4">Ported <b>wgpu</b>? <a
@@ -180,6 +169,17 @@
             <br>
 
             <div id="bindings_container"></div>
+        </div>
+        
+        <div class="container">
+            <h1 class="title is-1"><a name="showcase">#</a> Showcase</h1>
+            <br>
+            <p class="subtitle is-4">Made something cool with <b>wgpu</b>? <a
+                    href="https://github.com/gfx-rs/wgpu-rs.github.io">Make a PR</a>, and reach out to us on <a
+                    href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
+            <br>
+
+            <div id="showcase_container"></div>
         </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -200,6 +200,16 @@
     </script>
 
     <script>
+        // List of bindings
+        const bindings_list = [
+            {
+                "name": "wgpu4k",
+                "description": "Work-in-progress binding for Kotlin/Multiplatform",
+                "website": "https://GitHub.com/wgpu4k/wgpu4k",
+                "thumbnail": "https://google.com/favicon.ico"
+            }
+        ]
+        
         // List of showcase projects; Edit this list to add or remove projects
         const showcase_list = [
             {
@@ -406,15 +416,27 @@
             `;
         }
 
-        const showcase_container = document.getElementById("showcase_container");
+        const sections = [
+            {
+                "container": "bindings_container",
+                "entries": bindings_list
+            },
+            {
+                "container": "showcase_container",
+                "entries": showcase_list
+            }
+        ];
 
-        for (let { name, description, website, thumbnail } of showcase_list) {
-            showcase_container.insertAdjacentHTML("beforeend", showcase_template({
-                name,
-                description,
-                website,
-                thumbnail
-            }));
+        for (let { container, entries } of sections) {
+            const container_element = document.getElementById(container);
+            for (let { name, description, website, thumbnail } of entries) {
+                container_element.insertAdjacentHTML("beforeend", showcase_template({
+                    name,
+                    description,
+                    website,
+                    thumbnail
+                }));
+            }
         }
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -170,6 +170,17 @@
 
             <div id="showcase_container"></div>
         </div>
+
+        <div class="container">
+            <h1 class="title is-1"><a name="bindings">#</a> Bindings</h1>
+            <br>
+            <p class="subtitle is-4">Ported <b>wgpu</b>? <a
+                    href="https://github.com/gfx-rs/wgpu-rs.github.io">Make a PR</a>, and reach out to us on <a
+                    href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
+            <br>
+
+            <div id="bindings_container"></div>
+        </div>
     </section>
 
     <!-- Helper script for toggling the navigation-bar burger menu on small screens -->

--- a/index.html
+++ b/index.html
@@ -211,13 +211,13 @@
     </script>
 
     <script>
-        // List of bindings
+        // List of bindings; Edit this list to add or remove projects
         const bindings_list = [
             {
                 "name": "wgpu4k",
                 "description": "Work-in-progress binding for Kotlin/Multiplatform",
                 "website": "https://GitHub.com/wgpu4k/wgpu4k",
-                "thumbnail": "https://google.com/favicon.ico"
+                "thumbnail": "https://avatars.githubusercontent.com/u/163670885"
             }
         ]
         

--- a/index.html
+++ b/index.html
@@ -161,18 +161,127 @@
     <!-- Showcase Projects -->
     <section class="section is-medium">
         <div class="container">
-            <h1 class="title is-1"><a name="bindings">#</a> Bindings</h1>
+            <h1 class="title is-1"><a id="bindings">#</a> Bindings</h1>
             <br>
             <p class="subtitle is-4">Ported <b>wgpu</b>? <a
                     href="https://github.com/gfx-rs/wgpu-rs.github.io">Make a PR</a>, and reach out to us on <a
                     href="https://matrix.to/#/#wgpu-users:matrix.org">#wgpu-users</a>!</p>
             <br>
 
-            <div id="bindings_container"></div>
+            <table class="table">
+                 <thead>
+                <tr>
+                    <th>Language</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <th>C</th>
+                    <td><a href="https://github.com/gfx-rs/wgpu-native">wgpu-native</a></td>
+                    <td><i>Official native WebGPU implementation.</i></td>
+                </tr>
+                <tr>
+                    <th>C++</th>
+                    <td><a href="https://github.com/eliemichel/WebGPU-Cpp">WebGPU-C++</a></td>
+                    <td><i>An auto-generated C++ wrapper, developed for the <a href="https://eliemichel.github.io/LearnWebGPU">Learn WebGPU course</a>.</i></td>
+                </tr>
+                <tr>
+                    <th>Crystal</th>
+                    <td><a href="https://github.com/chances/wgpu-crystal">wgpu-crystal</a></td>
+                    <td><i>Bindings to wgpu-native for the Crystal programming language.</i></td>
+                </tr>
+                <tr>
+                    <th>D</th>
+                    <td><a href="https://code.dlang.org/packages/bindbc-wgpu">bindc-wgpu</a></td>
+                    <td><i>WebGPU for D, based on the <a href="https://github.com/BindBC/bindbc-loader">BindBC</a> library loader.</i></td>
+                </tr>
+                <tr>
+                    <th>Go</th>
+                    <td><a href="https://github.com/go-webgpu/webgpu">go-webpgu</a></td>
+                    <td><i>Zero-CGO wrapper for Go.</i></td>
+                </tr>
+                <tr>
+                    <th>Jai</th>
+                    <td><a href="https://github.com/SogoCZE/jai_wgpu_native">jai_wgpu_native</a></td>
+                    <td><i>Raw Jai bindings.</i></td>
+                </tr>
+                <tr>
+                    <th rowspan="2">Julia</th>
+                    <td><a href="https://github.com/dvijaha/WGPUNative.jl">WebGPUNative.jl</a></td>
+                    <td><i>Stable Julia wrapper.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/cshenton/WebGPU.jl">WebGPU.jl</a></td>
+                    <td><i>An experimental Julia wrapper.</i></td>
+                </tr>
+                <tr>
+                    <th rowspan="4">JVM</th>
+                    <td><a href="https://github.com/xpenatan/jWebGPU">jWebGPU</a></td>
+                    <td><i>WebGPU Java bindings for wgpu-native and Dawn.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/MonstrousSoftware/gdx-webgpu">gdx-webgpu</a></td>
+                    <td><i>Extensions to support jWebGPU on LibGDX.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/kgpu/kgpu/tree/master/wgpuj">kgpu/wgpuj</a></td>
+                    <td><i>Java and Kotlin/JVM wrapper.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/club-doki7/vulkan4j">vulkan4j</a></td>
+                    <td><i>Java 22+ wrapper (using FFM).</i></td>
+                </tr>
+                <tr>
+                    <th rowspan="3">Kotlin</th>
+                    <td><a href="https://github.com/wgpu4k/wgpu4k">wgpu4k-native</a></td>
+                    <td><i>Work-in-progress Kotlin/Multiplatform bindings for wgpu.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/wgpu4k/wgpu4k">wgpu4k</a></td>
+                    <td><i>Work-in-progress Kotlin/Multiplatform bindings for WebGPU.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://git.karmakrafts.dev/kk/multiplatform-wgpu">multiplatform-wgpu</a></td>
+                    <td><i>Multiplatform Kotlin/Native bindings for wgpu.</i></td>
+                </tr>
+                <tr>
+                    <th rowspan="3">.NET</th>
+                    <td><a href="https://github.com/dotnet/Silk.NET">Silk.NET</a></td>
+                    <td><i>The (official .NET) high-speed WebGPU bindings library your mother warned you about.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/amerkoleci/Alimer.Bindings">Alimer.Bindings.WebGPU</a></td>
+                    <td rowspan="2" style="text-color:#000;"><i>Cross platform .NET bindings.</i></td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/trivaxy/WGPU.NET">WGPU.NET</a></td>
+                </tr>
+                <tr>
+                    <th>Perl</th>
+                    <td><a href="https://metacpan.org/pod/WebGPU::Direct">WebGPU::Direct</a></td>
+                    <td><i>Direct access to WebGPU native APIs from Perl.</i></td>
+                </tr>
+                <tr>
+                    <th>Python</th>
+                    <td><a href="https://github.com/pygfx/wgpu-py">wgpu-py</a></td>
+                    <td><i>WebGPU for python.</i></td>
+                </tr>
+                <tr>
+                    <th>Scopes</th>
+                    <td><a href="https://gitlab.com/scopes-libraries/wgpu">scopes-libraries/wgpu</a></td>
+                    <td><i>Scopes wrapper for wgpu.</i></td>
+                </tr>
+                <tr>
+                    <th>Zig</th>
+                    <td><a href="https://github.com/bronter/wgpu_native_zig">wgpu_native_zig</a></td>
+                    <td><i>Zig bindings for wgpu-native.</i></td>
+                </tr>
+                </tbody>
+            </table>
         </div>
         
         <div class="container">
-            <h1 class="title is-1"><a name="showcase">#</a> Showcase</h1>
+            <h1 class="title is-1"><a id="showcase">#</a> Showcase</h1>
             <br>
             <p class="subtitle is-4">Made something cool with <b>wgpu</b>? <a
                     href="https://github.com/gfx-rs/wgpu-rs.github.io">Make a PR</a>, and reach out to us on <a
@@ -211,16 +320,6 @@
     </script>
 
     <script>
-        // List of bindings; Edit this list to add or remove projects
-        const bindings_list = [
-            {
-                "name": "wgpu4k",
-                "description": "Work-in-progress binding for Kotlin/Multiplatform",
-                "website": "https://GitHub.com/wgpu4k/wgpu4k",
-                "thumbnail": "https://avatars.githubusercontent.com/u/163670885"
-            }
-        ]
-        
         // List of showcase projects; Edit this list to add or remove projects
         const showcase_list = [
             {
@@ -427,29 +526,15 @@
             `;
         }
 
-        const sections = [
-            {
-                "container": "bindings_container",
-                "entries": bindings_list
-            },
-            {
-                "container": "showcase_container",
-                "entries": showcase_list
-            }
-        ];
+        const showcase_container = document.getElementById("showcase_container");
 
-        for (let { container, entries } of sections) {
-            const container_element = document.getElementById(container);
-            for (let { name, description, website, thumbnail } of entries) {
-                container_element.insertAdjacentHTML("beforeend", showcase_template({
-                    name,
-                    description,
-                    website,
-                    thumbnail
-                }));
-            }
-        }
+        for (let {name, description, website, thumbnail} of showcase_list)
+            showcase_container.insertAdjacentHTML("beforeend", showcase_template({
+            name,
+            description,
+            website,
+            thumbnail
+        }));
     </script>
 </body>
-
 </html>

--- a/index.html
+++ b/index.html
@@ -528,13 +528,15 @@
 
         const showcase_container = document.getElementById("showcase_container");
 
-        for (let {name, description, website, thumbnail} of showcase_list)
+        for (let { name, description, website, thumbnail } of showcase_list) {
             showcase_container.insertAdjacentHTML("beforeend", showcase_template({
-            name,
-            description,
-            website,
-            thumbnail
-        }));
+                name,
+                description,
+                website,
+                thumbnail
+            }));
+        }
     </script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -158,8 +158,8 @@
         </div>
     </section>
 
-    <!-- Showcase Projects -->
-    <section class="section is-medium">
+    <!-- Bindings -->
+    <section class="section">
         <div class="container">
             <h1 class="title is-1"><a id="bindings">#</a> Bindings</h1>
             <br>
@@ -169,7 +169,7 @@
             <br>
 
             <table class="table">
-                 <thead>
+                <thead>
                 <tr>
                     <th>Language</th>
                 </tr>
@@ -279,7 +279,10 @@
                 </tbody>
             </table>
         </div>
-        
+    </section>
+
+    <!-- Showcase Projects -->
+    <section class="section is-medium" style="padding-top: 0">
         <div class="container">
             <h1 class="title is-1"><a id="showcase">#</a> Showcase</h1>
             <br>

--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
                 </tr>
                 <tr>
                     <td><a href="https://github.com/amerkoleci/Alimer.Bindings">Alimer.Bindings.WebGPU</a></td>
-                    <td rowspan="2" style="text-color:#000;"><i>Cross platform .NET bindings.</i></td>
+                    <td rowspan="2"><i>Cross platform .NET bindings.</i></td>
                 </tr>
                 <tr>
                     <td><a href="https://github.com/trivaxy/WGPU.NET">WGPU.NET</a></td>


### PR DESCRIPTION
Known problems:
* I don't know how to fetch a repository's GitHub embed preview image, the one with the repository name and the colored languages bar. Currently, I just use google.com/favicon.ico (which doesn't even work...)
* There's a mysterious lack of padding between the showcase title and the bindings section.
* Need to add all other bindings.

![Screenshot_20241218-122147](https://github.com/user-attachments/assets/0d894989-30a7-4ce5-a31b-f5919440aadb)
